### PR TITLE
Avoid copyPixels for full-sheet frames.

### DIFF
--- a/spritesheet/Spritesheet.hx
+++ b/spritesheet/Spritesheet.hx
@@ -80,19 +80,34 @@ class Spritesheet {
 		
 		var frame = frames[index];
 		
-		var bitmapData = new BitmapData (frame.width, frame.height, true);
-		var sourceRectangle = new Rectangle (frame.x, frame.y, frame.width, frame.height);
-		var targetPoint = new Point ();
-		
-		bitmapData.copyPixels (sourceImage, sourceRectangle, targetPoint);
-		
-		if (sourceImageAlpha != null) {
+		if ( ( frame.x == 0 ) &&
+		     ( frame.y == 0 ) &&
+		     ( frame.width == sourceImage.width ) &&
+		     ( frame.height == sourceImage.height ) &&
+		     ( sourceImageAlpha == null ) ) {
 			
-			bitmapData.copyChannel (sourceImageAlpha, sourceRectangle, targetPoint, 2, 8);
+			// This is the full source image, and no alpha needs to be merged in;
+			// just reference directly.
+			//trace( "Spritesheet.generateBitmap: full sheet reused for " + name + " frame " + index );
+			frame.bitmapData = sourceImage;
+			
+		} else {
+			
+			var bitmapData = new BitmapData (frame.width, frame.height, true);
+			var sourceRectangle = new Rectangle (frame.x, frame.y, frame.width, frame.height);
+			var targetPoint = new Point ();
+			
+			bitmapData.copyPixels (sourceImage, sourceRectangle, targetPoint);
+			
+			if (sourceImageAlpha != null) {
+				
+				bitmapData.copyChannel (sourceImageAlpha, sourceRectangle, targetPoint, 2, 8);
+				
+			}
+			
+			frame.bitmapData = bitmapData;
 			
 		}
-		
-		frame.bitmapData = bitmapData;
 		
 	}
 	


### PR DESCRIPTION
Our toolchain is a little naive and occasionally produces a Spritesheet
with a single full-image frame.

This avoids taking copyPixels overhead when this happens, instead
referencing the existing sourceImage directly.  This does require that
sourceImageAlpha is null (otherwise the copyChannel would break this).

Posting this mostly as an RFC; I could see some possible arguments against it.