### PR TITLE
Discard sourceImage when all frames generated.

### DIFF
--- a/spritesheet/Spritesheet.hx
+++ b/spritesheet/Spritesheet.hx
@@ -94,6 +94,29 @@ class Spritesheet {
 		
 		frame.bitmapData = bitmapData;
 		
+		var hasGeneratedAllFrames = true;
+		for (i in 0...totalFrames) {
+			
+			if ( frames[i].bitmapData == null )
+			{
+				
+				hasGeneratedAllFrames = false;
+				break;
+				
+			}
+			
+		}
+		
+		if ( hasGeneratedAllFrames ) {
+			
+			// We've generated all frames, don't need to keep the original spritesheet anymore.
+			// Should not break merge() or updateImage() or similar.
+			//trace( "Spritesheet.generateBitmap: all frames generated, evicting source." );
+			sourceImage = null;
+			sourceImageAlpha = null;
+			
+		}
+		
 	}
 	
 	


### PR DESCRIPTION
After the final frame is pulled in by generateBitmap(i) call, it appears
we can safely null both sourceImage and sourceImageAlpha.

The usual uses of merge and updateImage and other methods seems to be
supported; the one case this might break is a "merge with another
spritesheet with the same sourceImage and sourceImageAlpha as ourselves",
causing it to generate frames earlier than it would have otherwise.

Once again, I could see some arguments against this, so posting as an RFC.  It's been fairly effective at memory reduction in mobile browsers for us.